### PR TITLE
Deduplicate output when logs not found

### DIFF
--- a/scripts/crashplan.py
+++ b/scripts/crashplan.py
@@ -39,8 +39,6 @@ if os.path.exists(crashplan_log):
 else:
     if os.path.exists(crashplan_log_0):
         crashplan_log = crashplan_log_0
-    else:
-        print "CrashPlan log not found here: %s or %s" % (crashplan_log, crashplan_log_0)
 
 # crashplan logformat
 regex = re.compile(r'. (\d+\/\d+\/\d+ \d+:\d+[AP]M)\s+(\[[^\]]+\])\s+(.*)')
@@ -81,7 +79,7 @@ if os.path.exists(crashplan_log):
                         destinations[destination]['last_failure'] = timestamp
                         destinations[destination]['reason'] = 'unknown'
 else:
-    print "CrashPlan log not found here: %s " % crashplan_log
+    print "CrashPlan log not found at: %s or %s" % (crashplan_log, crashplan_log_0)
     
 # Make sure cachedir exists
 cachedir = '%s/cache' % os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
Suggestion to clean up log output

Current output when no CrashPlan logs are found:
```
Running crashplan.py
CrashPlan log not found here: /Library/Logs/CrashPlan/history.log or /Library/Logs/CrashPlan/history.log.0
CrashPlan log not found here: /Library/Logs/CrashPlan/history.log
```

Output with proposed fix when no CrashPlan logs are found:
```
Running crashplan.py
CrashPlan log not found at: /Library/Logs/CrashPlan/history.log or /Library/Logs/CrashPlan/history.log.0
```